### PR TITLE
Request queue

### DIFF
--- a/CloverSDK.podspec
+++ b/CloverSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CloverSDK"
-  s.version      = "0.3.1"
+  s.version      = "0.3.5"
   s.summary      = "Clover SDK"
   s.homepage     = "https://github.com/clover/clover-ios-sdk"
   s.license      = { :type => "Apache License 2.0", :file => "LICENSE" }

--- a/CloverSDK/Info.plist
+++ b/CloverSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.3.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/CloverSDK/PromiseKit/CLVRequestExt+PK.swift
+++ b/CloverSDK/PromiseKit/CLVRequestExt+PK.swift
@@ -22,7 +22,9 @@ extension CLVRequest {
         switch validation {
         case .SUCCESS(let value): fulfill(self.mapObject(value)!)
         case .FAILURE(let error): reject(error)
-        case .TOO_MANY_REQUESTS_EXCEPTION_429: self.makeRequestObjWithPromise(0, fulfill, reject)
+        case .TOO_MANY_REQUESTS_EXCEPTION_429:
+          if CLVRequest.retryFailedRequestsWith429 { self.makeRequestObjWithPromise(0, fulfill, reject) }
+          else { reject(CLVError.TooManyRequestsException) }
         }
       }
     }
@@ -35,7 +37,9 @@ extension CLVRequest {
         switch validation {
         case .SUCCESS(let value): fulfill(self.mapObject(value)!); self.log429Success(retryCount)
         case .FAILURE(let error): reject(error)
-        case .TOO_MANY_REQUESTS_EXCEPTION_429: self.makeRequestObjWithPromise(retryCount + 1, fulfill, reject)
+        case .TOO_MANY_REQUESTS_EXCEPTION_429:
+          if retryCount < CLVRequest.retryCountAfter429 { self.makeRequestObjWithPromise(retryCount + 1, fulfill, reject) }
+          else { reject(CLVError.TooManyRequestsException) }
         }
       }
     }
@@ -48,7 +52,9 @@ extension CLVRequest {
         switch validation {
         case .SUCCESS(let value): fulfill(self.mapArray(value))
         case .FAILURE(let error): reject(error)
-        case .TOO_MANY_REQUESTS_EXCEPTION_429: self.makeRequestArrWithPromise(0, fulfill, reject)
+        case .TOO_MANY_REQUESTS_EXCEPTION_429:
+          if CLVRequest.retryFailedRequestsWith429 { self.makeRequestArrWithPromise(0, fulfill, reject) }
+          else { reject(CLVError.TooManyRequestsException) }
         }
       }
     }
@@ -61,7 +67,9 @@ extension CLVRequest {
         switch validation {
         case .SUCCESS(let value): fulfill(self.mapArray(value)); self.log429Success(retryCount)
         case .FAILURE(let error): reject(error)
-        case .TOO_MANY_REQUESTS_EXCEPTION_429: self.makeRequestArrWithPromise(retryCount + 1, fulfill, reject)
+        case .TOO_MANY_REQUESTS_EXCEPTION_429:
+          if retryCount < CLVRequest.retryCountAfter429 { self.makeRequestArrWithPromise(retryCount + 1, fulfill, reject) }
+          else { reject(CLVError.TooManyRequestsException) }
         }
       }
     }
@@ -74,7 +82,9 @@ extension CLVRequest {
         switch validation {
         case .SUCCESS(let value): fulfill(self.mapAnyObject(value))
         case .FAILURE(let error): reject(error)
-        case .TOO_MANY_REQUESTS_EXCEPTION_429: self.makeRequestWithPromise(0, fulfill, reject)
+        case .TOO_MANY_REQUESTS_EXCEPTION_429:
+          if CLVRequest.retryFailedRequestsWith429 { self.makeRequestWithPromise(0, fulfill, reject) }
+          else { reject(CLVError.TooManyRequestsException) }
         }
       }
     }
@@ -87,7 +97,9 @@ extension CLVRequest {
         switch validation {
         case .SUCCESS(let value): fulfill(self.mapAnyObject(value)); self.log429Success(retryCount)
         case .FAILURE(let error): reject(error)
-        case .TOO_MANY_REQUESTS_EXCEPTION_429: self.makeRequestWithPromise(retryCount + 1, fulfill, reject)
+        case .TOO_MANY_REQUESTS_EXCEPTION_429:
+          if retryCount < CLVRequest.retryCountAfter429 { self.makeRequestWithPromise(retryCount + 1, fulfill, reject) }
+          else { reject(CLVError.TooManyRequestsException) }
         }
       }
     }

--- a/CloverSDK/Utils/CLVError.swift
+++ b/CloverSDK/Utils/CLVError.swift
@@ -11,12 +11,14 @@ import Foundation
 public enum CLVError: ErrorType {
   case Error(NSError)
   case UnacceptableStatusCode(statusCode: Int, serverMessage: String)
+  case TooManyRequestsException
   case UnknownError
   
   public var error: NSError {
     switch self {
     case .Error(let error): return error
     case .UnacceptableStatusCode(let statusCode, let serverMessage): return CLVError.generateNSError(code: -42, userInfo: ["statusCode": statusCode, "serverMessage": serverMessage])
+    case .TooManyRequestsException: return CLVError.generateNSError(code: -429, userInfo: ["statusCode": 429])
     case .UnknownError: return CLVError.generateNSError()
     }
   }

--- a/CloverSDK/Utils/CLVRequest.swift
+++ b/CloverSDK/Utils/CLVRequest.swift
@@ -12,6 +12,13 @@ import ObjectMapper
 
 public class CLVRequest {
   
+  static var retryFailedRequestsWith429: Bool = true
+  private static var retryCount: Int = 5
+  static var retryCountAfter429: Int {
+    get { return self.retryCount }
+    set { self.retryCount = newValue <= 5 ? newValue : 5 }
+  }
+  
   // MARK: - Properties
   
   let httpMethod: Alamofire.Method

--- a/CloverSDK/Utils/CLVRequest.swift
+++ b/CloverSDK/Utils/CLVRequest.swift
@@ -19,6 +19,10 @@ public class CLVRequest {
     set { self.retryCount = newValue <= 5 ? newValue : 5 }
   }
   
+  static var autoDelayRequests: Bool = true
+  static var requestRateLimit: Int = 15
+  static var requestRateLimitTime: Double = 1 / Double(CLVRequest.requestRateLimit)
+  
   // MARK: - Properties
   
   let httpMethod: Alamofire.Method

--- a/CloverSDK/Utils/CLVRequest.swift
+++ b/CloverSDK/Utils/CLVRequest.swift
@@ -56,6 +56,7 @@ public class CLVRequest {
     case CREATED_TIME = "createdTime"
     case CLIENT_CREATED_TIME = "clientCreatedTime"
     case TIMESTAMP = "timestamp"
+    case START_END_TIMESTAMP
   }
   
   public struct CloverAPITimeFilters {
@@ -73,9 +74,6 @@ public class CLVRequest {
   
   // MARK: - Helper Methods
   
-  internal class func getApiDateFilters(beginningTime: NSDate, endTime: NSDate, timeFilterType: TimeFilterType) -> String {
-    return "filter=\(timeFilterType.rawValue)%3E\(Int64(beginningTime.timeIntervalSince1970 * 1000))&filter=\(timeFilterType.rawValue)%3C\(Int64(endTime.timeIntervalSince1970 * 1000))"
-  }
   
   internal class func getFiltersUrlString(filters: [String:String]) -> String {
     return filters.map({(k,v) in return "filter=\(k)=\(v)"}).joinWithSeparator("&")
@@ -119,12 +117,13 @@ public class CLVRequest {
   }
   
   private func getTimeFilters() -> String {
-    guard let timeFilters = timeFilters else { return "" }
-    let timeFilterType = timeFilters.timeFilterType.rawValue
-    var res = [String]()
-    if let startTime = timeFilters.startTime { res.append("filter=\(timeFilterType)>\(Int64(startTime.timeIntervalSince1970 * 1000))") }
-    if let endTime   = timeFilters.endTime   { res.append("filter=\(timeFilterType)<\(Int64(endTime.timeIntervalSince1970   * 1000))") }
-    return res.isEmpty ? "" : res.joinWithSeparator("&")
+    guard let timeFilters = timeFilters, startTime = timeFilters.startTime, endTime = timeFilters.endTime else { return "" }
+    let start = Int64(startTime.timeIntervalSince1970 * 1000)
+    let end = Int64(endTime.timeIntervalSince1970 * 1000)
+    switch timeFilters.timeFilterType {
+    case .START_END_TIMESTAMP: return "startTimestamp=\(start)&endTimestamp=\(end)"
+    default: return "filter=\(timeFilters.timeFilterType.rawValue)>\(start)&filter=\(timeFilters.timeFilterType.rawValue)<\(end)"
+    }
   }
   
   private func getExpands() -> String {
@@ -233,7 +232,7 @@ public class CLVRequest {
     public func addPathParams(pathParams: [String:String])             -> Builder { self.pathParams.updateContentsOf(pathParams); return self }
     public func removePathParams(pathParams: [String:String])          -> Builder { self.pathParams.removeContentsOf(pathParams); return self }
     public func removePathParams(keys: [String])                       -> Builder { self.pathParams.removeContentsOf(keys); return self }
-
+    
     /// Update params with contents of
     public func addParams(params: [String:String])                     -> Builder { self.params.updateContentsOf(params); return self }
     /// Remove params that exist in

--- a/CloverSDK/Utils/CLVRequestExtension.swift
+++ b/CloverSDK/Utils/CLVRequestExtension.swift
@@ -101,6 +101,33 @@ extension CLVRequest {
   }
   
   
+  // MARK: - CLVRequestQueue
+  
+  class CLVRequestQueue {
+    private static var queue: [() -> Void] = []
+    weak private static var timer: NSTimer?
+    
+    class func addRequestToQueue(request: () -> Void) {
+      queue.append(request)
+      activateTimer()
+    }
+    
+    @objc private class func makeFirstRequest() {
+      if !queue.isEmpty { queue.removeFirst()() }
+      else { deactivateTimer() }
+    }
+    
+    private class func activateTimer() {
+      guard timer == nil else { return }
+      timer = NSTimer.scheduledTimerWithTimeInterval(CLVRequest.requestRateLimitTime, target: self, selector: #selector(makeFirstRequest), userInfo: nil, repeats: true)
+    }
+    
+    private class func deactivateTimer() {
+      timer?.invalidate()
+    }
+  }
+  
+  
   // MARK: - Helpers
   
   // Closures to handle data in success calls:
@@ -114,12 +141,17 @@ extension CLVRequest {
       return
     }
     
-    Alamofire
-      .request(httpMethod, getUrlString(), parameters: payload, encoding: .JSON, headers: getHeaders())
-      .validate()
-      .responseJSON { response in
-        switchBlock(self.validateResponse(response: response))
+    let makeRequestBlock: () -> Void = {
+      Alamofire
+        .request(self.httpMethod, self.getUrlString(), parameters: self.payload, encoding: .JSON, headers: self.getHeaders())
+        .validate()
+        .responseJSON { response in
+          switchBlock(self.validateResponse(response: response))
+      }
     }
+    
+    if CLVRequest.autoDelayRequests { CLVRequestQueue.addRequestToQueue(makeRequestBlock) }
+    else { makeRequestBlock() }
   }
   
   internal enum CLVValidation {

--- a/CloverSDK/Utils/CLVRequestExtension.swift
+++ b/CloverSDK/Utils/CLVRequestExtension.swift
@@ -22,7 +22,9 @@ extension CLVRequest {
       switch validation {
       case .SUCCESS(let value): success(self.mapObject(value))
       case .FAILURE(let error): failure(error)
-      case .TOO_MANY_REQUESTS_EXCEPTION_429: self.makeRequestObj(0, success, failure)
+      case .TOO_MANY_REQUESTS_EXCEPTION_429:
+        if CLVRequest.retryFailedRequestsWith429 { self.makeRequestObj(0, success, failure) }
+        else { failure(CLVError.TooManyRequestsException) }
       }
     }
   }
@@ -34,7 +36,9 @@ extension CLVRequest {
         switch validation {
         case .SUCCESS(let value): success(self.mapObject(value)); self.log429Success(retryCount)
         case .FAILURE(let error): failure(error)
-        case .TOO_MANY_REQUESTS_EXCEPTION_429: self.makeRequestObj(retryCount + 1, success, failure)
+        case .TOO_MANY_REQUESTS_EXCEPTION_429:
+          if retryCount < CLVRequest.retryCountAfter429 { self.makeRequestObj(retryCount + 1, success, failure) }
+          else { failure(CLVError.TooManyRequestsException) }
         }
       }
     }
@@ -46,7 +50,9 @@ extension CLVRequest {
       switch validation {
       case .SUCCESS(let value): success(self.mapArray(value))
       case .FAILURE(let error): failure(error)
-      case .TOO_MANY_REQUESTS_EXCEPTION_429: self.makeRequestArr(0, success, failure)
+      case .TOO_MANY_REQUESTS_EXCEPTION_429:
+        if CLVRequest.retryFailedRequestsWith429 { self.makeRequestArr(0, success, failure) }
+        else { failure(CLVError.TooManyRequestsException) }
       }
     }
   }
@@ -58,7 +64,9 @@ extension CLVRequest {
         switch validation {
         case .SUCCESS(let value): success(self.mapArray(value)); self.log429Success(retryCount)
         case .FAILURE(let error): failure(error)
-        case .TOO_MANY_REQUESTS_EXCEPTION_429: self.makeRequestArr(retryCount + 1, success, failure)
+        case .TOO_MANY_REQUESTS_EXCEPTION_429:
+          if retryCount < CLVRequest.retryCountAfter429 { self.makeRequestArr(retryCount + 1, success, failure) }
+          else { failure(CLVError.TooManyRequestsException) }
         }
       }
     }
@@ -70,7 +78,9 @@ extension CLVRequest {
       switch validation {
       case .SUCCESS(let value): success(self.mapAnyObject(value))
       case .FAILURE(let error): failure(error)
-      case .TOO_MANY_REQUESTS_EXCEPTION_429: self.makeRequest(0, success, failure)
+      case .TOO_MANY_REQUESTS_EXCEPTION_429:
+        if CLVRequest.retryFailedRequestsWith429 { self.makeRequest(0, success, failure) }
+        else { failure(CLVError.TooManyRequestsException) }
       }
     }
   }
@@ -82,7 +92,9 @@ extension CLVRequest {
         switch validation {
         case .SUCCESS(let value): success(self.mapAnyObject(value))
         case .FAILURE(let error): failure(error)
-        case .TOO_MANY_REQUESTS_EXCEPTION_429: self.makeRequest(retryCount + 1, success, failure)
+        case .TOO_MANY_REQUESTS_EXCEPTION_429:
+          if retryCount < CLVRequest.retryCountAfter429 { self.makeRequest(retryCount + 1, success, failure) }
+          else { failure(CLVError.TooManyRequestsException) }
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -72,7 +72,32 @@ session.getMerchantEmployees(
 })
 ```
 
-- CloverSDK handles 429 (too many requests) error cases by retrying the same request with exponentially increasing time delays.
+- Debug output:
+
+If debugMode is set to true (false by default) the options passed to debugPrintOptions will be printed on each request.
+
+```
+CLVSession.debugMode = true
+CLVSession.debugPrintOptions = [.URL, .TIME_FILTERS, .HEADERS, .PAYLOAD, .STATUS_CODE, .RESPONSE_DATA]
+```
+
+- Handling request rate limits:
+
+If autoDelayRequests is set to true (true by default) SDK will spread the requests over time to be within the set rate limits (15/sec by default.)
+
+```
+CLVRequest.autoDelayRequests = true
+CLVRequest.requestRateLimit = 16
+```
+
+- Handling 429 Too Many Requests errors:
+
+If retryFailedRequestsWith429 is set to true (true by default) SDK will handle 429 error cases by retrying the same request with exponentially increasing time delays.
+
+```
+CLVRequest.retryFailedRequestsWith429 = true
+CLVRequest.retryCountAfter429 = 5
+```
 
 # Components of the Clover iOS SDK:
 


### PR DESCRIPTION
New features in this pr:
- Add startTimestamp / endTimestamp option to time filters; I needed this in Dashboard to use non-revenue items.
- 429 handling didn't have an option to be disabled and no cap on retry counts; now it has :)
- Most importantly, I created a CLVRequestQueue class to auto-delay all requests. :) Basically:
  - when a request is added to the queue, it will start the timer which will make a request every 1/15 secs.
  - when there're no requests left in the queue, it will stop the timer.
- Updated version number

I will add some description for these features in the README before merging this pr.

@arjand @alexclover 
